### PR TITLE
Build Jira task processing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ The main workflow (`process-epic`) performs the following steps:
 5. **Generate Coding Prompt**: Uses AI to create a comprehensive coding prompt
 6. **Save and Output**: Saves the prompt to a temp file and outputs to stdout
 
+## Workflow Types
+
+### Epic Workflow vs Issue Workflow
+
+- **`process-epic`**: Processes an entire epic by finding the next available "ready" ticket within the epic and claiming it. Best for organized epic-based development workflows.
+
+- **`process-issue`**: Processes a specific individual JIRA issue directly. Best for working on specific tickets or when you want to claim a particular issue regardless of epic structure.
+
 ## Commands
 
 ### `process-epic <epic-id>`
@@ -83,6 +91,21 @@ poolside process-epic PROJ-123 --agent "Cursor Agent" --claimant "Developer Bot"
 
 - `-a, --agent <name>`: Name of the agent claiming the ticket (default: "Coding Agent")
 - `-c, --claimant <name>`: Name to use when claiming the ticket (defaults to agent name)
+- `--verbose`: Enable verbose logging for debugging
+
+### `process-issue <issue-id>`
+
+Process a JIRA issue to claim it and generate a coding prompt.
+
+```bash
+poolside process-issue PROJ-456 --agent "Cursor Agent" --claimant "Developer Bot"
+```
+
+**Options:**
+
+- `-a, --agent <name>`: Name of the agent claiming the issue (default: "Coding Agent")
+- `-c, --claimant <name>`: Name to use when claiming the issue (defaults to agent name)
+- `--dry-run`: Preview changes without actually claiming the issue
 - `--verbose`: Enable verbose logging for debugging
 
 ### `list-epics <project-key>`
@@ -200,6 +223,22 @@ poolside process-epic PROJ-123 --agent "Claude Agent"
 
 # Use different names for agent and claimant
 poolside process-epic PROJ-123 --agent "Cursor Agent" --claimant "John Doe"
+```
+
+### Basic Issue Processing
+
+```bash
+# Process a single JIRA issue
+poolside process-issue PROJ-456
+
+# Use a custom agent name
+poolside process-issue PROJ-456 --agent "Claude Agent"
+
+# Use different names for agent and claimant
+poolside process-issue PROJ-456 --agent "Cursor Agent" --claimant "John Doe"
+
+# Dry run to preview changes without claiming
+poolside process-issue PROJ-456 --dry-run
 ```
 
 ### Epic Management

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agent-workflow-cli",
+  "name": "poolside",
   "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-workflow-cli",
+      "name": "poolside",
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
@@ -23,7 +23,7 @@
         "ora": "^8.0.1"
       },
       "bin": {
-        "agent-workflow": "dist/index.js"
+        "poolside": "dist/index.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/tests/process-issue.test.ts
+++ b/tests/process-issue.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { IntegrationUtils } from "../src/integration-utils.js";
+
+describe("Process Issue Command", () => {
+  let mockConfig: any;
+  let utils: IntegrationUtils;
+
+  beforeEach(() => {
+    mockConfig = {
+      jira: {
+        host: "https://test.atlassian.net",
+        username: "test@example.com",
+        password: "test-token",
+      },
+      ai: {
+        apiKey: "test-api-key",
+      },
+      verbose: false,
+    };
+  });
+
+  it("should have processIssue method", () => {
+    utils = new IntegrationUtils(mockConfig);
+    expect(utils.processIssue).toBeDefined();
+    expect(typeof utils.processIssue).toBe("function");
+  });
+
+  it("should accept correct parameters", () => {
+    utils = new IntegrationUtils(mockConfig);
+    
+    // Test that the method accepts the expected parameters
+    const processIssueMethod = utils.processIssue;
+    expect(processIssueMethod.length).toBe(1); // issueId (options has default value)
+  });
+
+  it("should have correct interface definitions", () => {
+    // This test documents the expected interface structure
+    const expectedOptions = {
+      agentName: "Test Agent",
+      claimantName: "Test Claimant",
+      dryRun: true,
+    };
+
+    const expectedResult = {
+      issue: {
+        key: "PROJ-123",
+        summary: "Test Issue",
+        description: "Test Description",
+        status: "Ready",
+        assignee: null,
+        reporter: "Test Reporter",
+        created: "2023-01-01T00:00:00.000Z",
+        updated: "2023-01-01T00:00:00.000Z",
+        labels: [],
+        components: [],
+        priority: "Medium",
+        issueType: "Task",
+        comments: [],
+        url: "https://test.atlassian.net/browse/PROJ-123",
+      },
+      prompt: "Generated coding prompt",
+      tempFile: "/tmp/PROJ-123-prompt.md",
+    };
+
+    // This test serves as documentation of the expected interfaces
+    expect(expectedOptions).toHaveProperty("agentName");
+    expect(expectedOptions).toHaveProperty("claimantName");
+    expect(expectedOptions).toHaveProperty("dryRun");
+    
+    expect(expectedResult).toHaveProperty("issue");
+    expect(expectedResult).toHaveProperty("prompt");
+    expect(expectedResult).toHaveProperty("tempFile");
+  });
+});


### PR DESCRIPTION
Add `process-issue` command to allow direct processing of individual JIRA issues, reusing existing integration utilities.

This command provides a direct way to process any specific JIRA issue by ID, complementing the existing `process-epic` command which focuses on finding the next available ticket within an epic. It reuses the core JIRA, AI, and file output logic for consistency.